### PR TITLE
fix: ユーザーが最初に通知を許可したとき、エラーが発生する問題を解消

### DIFF
--- a/frontend/src/pages/user/[id].tsx
+++ b/frontend/src/pages/user/[id].tsx
@@ -69,8 +69,9 @@ const useInitFirebase = () => {
       const messaging = getMessaging(app);
       try {
         const currentToken = await getToken(messaging);
-        setIsNotification(true);
-        if (!currentToken) {
+        if (currentToken) {
+          setIsNotification(true);
+        } else {
           console.error("No Instance ID token available. Request permission to generate one.");
         }
       } catch (error) {

--- a/frontend/src/pages/user/[id].tsx
+++ b/frontend/src/pages/user/[id].tsx
@@ -66,19 +66,17 @@ const useInitFirebase = () => {
         setIsNotification(false);
         return;
       }
-
       const messaging = getMessaging(app);
-      let currentToken;
       try {
-        currentToken = await getToken(messaging);
-      } catch {
-        router.reload();
-      }
-      if (currentToken) {
+        const currentToken = await getToken(messaging);
         setIsNotification(true);
-      } else {
-        console.error("No Instance ID token available. Request permission to generate one.");
+        if (!currentToken) {
+          console.error("No Instance ID token available. Request permission to generate one.");
+        }
+      } catch (error) {
+        console.error("Error getting token:", error);
         setIsNotification(false);
+        router.reload();
       }
     };
 

--- a/frontend/src/pages/user/[id].tsx
+++ b/frontend/src/pages/user/[id].tsx
@@ -53,7 +53,7 @@ const ButtonContainer = styled.div`
 const followingNumber = 3;
 const callNumber = 321;
 
-const useInitFirebase = async () => {
+const useInitFirebase = () => {
   const [isNotification, setIsNotification] = useState(false);
 
   useEffect(() => {

--- a/frontend/src/pages/user/[id].tsx
+++ b/frontend/src/pages/user/[id].tsx
@@ -62,7 +62,9 @@ const useInitFirebase = () => {
     const requestNotificationPermission = async () => {
       const permission = await Notification.requestPermission();
       if (permission !== "granted") {
-        throw new Error("Permission not granted for Notification");
+        console.error("Permission not granted for Notification");
+        setIsNotification(false);
+        return;
       }
 
       const messaging = getMessaging(app);

--- a/frontend/src/pages/user/[id].tsx
+++ b/frontend/src/pages/user/[id].tsx
@@ -56,6 +56,7 @@ const callNumber = 321;
 
 const useInitFirebase = () => {
   const [isNotification, setIsNotification] = useState(false);
+  const [isToken, setIsToken] = useState(false);
   const router = useRouter();
 
   useEffect(() => {
@@ -70,8 +71,10 @@ const useInitFirebase = () => {
       try {
         const currentToken = await getToken(messaging);
         setIsNotification(true);
+        setIsToken(true);
         if (!currentToken) {
           console.error("No Instance ID token available. Request permission to generate one.");
+          setIsToken(false);
         }
       } catch (error) {
         console.error("Error getting token:", error);
@@ -83,11 +86,11 @@ const useInitFirebase = () => {
     requestNotificationPermission();
   }, [router]);
 
-  return isNotification;
+  return [isNotification, isToken];
 };
 
 const ClientPage: FC = () => {
-  const isNotification = useInitFirebase();
+  const [isNotification, isToken] = useInitFirebase();
   const onLogin = () => {};
 
   if (!isNotification) {
@@ -111,13 +114,19 @@ const ClientPage: FC = () => {
   return (
     <ClientPageContainer>
       <CircleContainer>
-        <MessageCricle message={callNumber} />
+        {isToken ? <MessageCricle message={callNumber} /> : <MessageCricle message={""} />}
         <CircleText>あなたの呼出番号は</CircleText>
       </CircleContainer>
-      <WaitingContainer>
-        <Text>現在の待ち人数</Text>
-        <Number>{followingNumber}人</Number>
-      </WaitingContainer>
+      {isToken ? (
+        <WaitingContainer>
+          <Text>現在の待ち人数</Text>
+          <Number>{followingNumber}人</Number>
+        </WaitingContainer>
+      ) : (
+        <WaitingContainer>
+          <Text>番号が発行されません</Text>
+        </WaitingContainer>
+      )}
       <ButtonContainer>
         <GetOutButton onClick={onLogin} />
       </ButtonContainer>

--- a/frontend/src/pages/user/[id].tsx
+++ b/frontend/src/pages/user/[id].tsx
@@ -58,18 +58,24 @@ const useInitFirebase = async () => {
 
   useEffect(() => {
     const requestNotificationPermission = async () => {
-      const permission = await Notification.requestPermission();
-      if (permission !== "granted") {
-        throw new Error("Permission not granted for Notification");
-      }
+      try {
+        const permission = await Notification.requestPermission();
+        if (permission !== "granted") {
+          throw new Error("Permission not granted for Notification");
+        }
 
-      const messaging = getMessaging(app);
-      const currentToken = await getToken(messaging);
-      if (currentToken) {
-        setIsNotification(true);
+        const messaging = getMessaging(app);
+        const currentToken = await getToken(messaging);
+        if (currentToken) {
+          setIsNotification(true);
+        } else {
+          console.error("No Instance ID token available. Request permission to generate one.");
+          setIsNotification(false);
+        }
+      } catch (error) {
+        console.error(error);
+        setIsNotification(false);
       }
-      console.error("No Instance ID token available. Request permission to generate one.");
-      setIsNotification(false);
     };
 
     requestNotificationPermission();

--- a/frontend/src/pages/user/[id].tsx
+++ b/frontend/src/pages/user/[id].tsx
@@ -1,4 +1,5 @@
 import { getMessaging, getToken } from "firebase/messaging";
+import { useRouter } from "next/router";
 import { FC, useEffect, useState } from "react";
 import styled from "styled-components";
 import { GetOutButton } from "../../components/getout/GetOutButton";
@@ -53,8 +54,9 @@ const ButtonContainer = styled.div`
 const followingNumber = 3;
 const callNumber = 321;
 
-const useInitFirebase = async () => {
+const useInitFirebase = () => {
   const [isNotification, setIsNotification] = useState(false);
+  const router = useRouter();
 
   useEffect(() => {
     const requestNotificationPermission = async () => {
@@ -64,23 +66,30 @@ const useInitFirebase = async () => {
       }
 
       const messaging = getMessaging(app);
-      const currentToken = await getToken(messaging);
+      let currentToken;
+      try {
+        currentToken = await getToken(messaging);
+      } catch {
+        router.reload();
+      }
       if (currentToken) {
         setIsNotification(true);
+      } else {
+        console.error("No Instance ID token available. Request permission to generate one.");
+        setIsNotification(false);
       }
-      console.error("No Instance ID token available. Request permission to generate one.");
-      setIsNotification(false);
     };
 
     requestNotificationPermission();
-  }, []);
+  }, [router]);
 
   return isNotification;
 };
 
 const ClientPage: FC = () => {
-  const onLogin = () => {};
   const isNotification = useInitFirebase();
+  const onLogin = () => {};
+
   if (!isNotification) {
     return (
       <>


### PR DESCRIPTION
- 初期状態から通知を許可するとエラーを吐いて再読み込みしないと解消しない状態を改善
- そのエラーの状態になったときに自動でリロードするように変更
- 画面遷移を修正
- useInitFirebaseを普通の関数からカスタムフックに